### PR TITLE
used box-shadow for d2l-button focus style

### DIFF
--- a/d2l-button-shared-styles.html
+++ b/d2l-button-shared-styles.html
@@ -1,7 +1,11 @@
 <link rel="import" href="../polymer/polymer.html">
 <style is="custom-style">
 	html {
+		--d2l-button-focus: {
+			box-shadow: 0 0 0 4px var(--d2l-color-celestine-light);
+		};
 		--d2l-button-spacing: 0.75rem;
+		--d2l-color-celestine-light: rgba(0, 111, 191, 0.3);
 	}
 	.d2l-button-spacing {
 		margin-right: var(--d2l-button-spacing);

--- a/d2l-button-shared-styles.html
+++ b/d2l-button-shared-styles.html
@@ -5,10 +5,9 @@
 			box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
 		};
 		--d2l-button-focus: {
-			box-shadow: 0 0 0 4px var(--d2l-color-celestine-light);
+			box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
 		};
 		--d2l-button-spacing: 0.75rem;
-		--d2l-color-celestine-light: rgba(0, 111, 191, 0.3);
 	}
 	.d2l-button-spacing {
 		margin-right: var(--d2l-button-spacing);

--- a/d2l-button-shared-styles.html
+++ b/d2l-button-shared-styles.html
@@ -1,6 +1,9 @@
 <link rel="import" href="../polymer/polymer.html">
 <style is="custom-style">
 	html {
+		--d2l-button-clear-focus: {
+			box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
+		};
 		--d2l-button-focus: {
 			box-shadow: 0 0 0 4px var(--d2l-color-celestine-light);
 		};

--- a/d2l-button.html
+++ b/d2l-button.html
@@ -32,6 +32,7 @@
 				white-space: nowrap;
 				width: auto;
 				@apply(--d2l-button);
+				@apply(--d2l-button-clear-focus);
 			}
 			/* Firefox includes a hidden border which messes up button dimensions */
 			:host(::-moz-focus-inner) {

--- a/d2l-button.html
+++ b/d2l-button.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="d2l-button-shared-styles.html">
 
 <dom-module id="d2l-button">
 	<template>
@@ -22,6 +23,7 @@
 				outline: none;
 				padding: 0.5rem 1.5rem;
 				text-align: center;
+				transition: box-shadow 0.2s;
 				-webkit-user-select: none;
 				-moz-user-select: none;
 				-ms-user-select: none;
@@ -40,10 +42,15 @@
 				border-color: var(--d2l-color-titanius);
 				color: var(--d2l-color-ferrite);
 			}
-			:host(:hover), :host(:focus), :host(.d2l-button-focus) {
+
+			:host(:hover) {
 				background-color: var(--d2l-color-gypsum);
 				@apply(--d2l-button-hover);
 			}
+			:host(:focus), :host(.d2l-button-focus) {
+				@apply(--d2l-button-focus);
+			}
+
 			:host([disabled]) {
 				opacity: 0.5;
 				cursor: default;
@@ -54,9 +61,13 @@
 				color: var(--d2l-color-white);
 				@apply(--d2l-button-primary);
 			}
-			:host([primary]:hover), :host([primary]:focus), :host([primary].d2l-button-focus) {
+
+			:host([primary]:hover) {
 				background-color: var(--d2l-color-celestuba);
 				@apply(--d2l-button-primary-hover);
+			}
+			:host([primary]:focus), :host([primary].d2l-button-focus) {
+				@apply(--d2l-button-focus);
 			}
 		</style>
 		<content></content>


### PR DESCRIPTION
Design details come from DE23228.

Two problems not addressed:
1. box-shadow color is not "brandable" (created rgba color instead of using primary color directly)
2. Button focus from click (mousedown) without js isn't achievable. 