### PR TITLE
min-height attribute for floating buttons (min viewport height for fl…

### DIFF
--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -68,7 +68,7 @@
 			}
 		</style>
 
-		<iron-media-query query="(max-height: 500px)" query-matches="{{_heightAtMost500px}}"></iron-media-query>
+		<iron-media-query query="(max-height: {{minHeight}})" query-matches="{{_viewportIsMinHeight}}"></iron-media-query>
 
 		<div class="d2l-floating-buttons-container">
 			<div><content></content></div>
@@ -82,7 +82,12 @@
 			is: 'd2l-floating-buttons',
 
 			properties: {
-				_heightAtMost500px: Boolean
+				minHeight: {
+					reflectToAttribute: true,
+					type: String,
+					value: '500px'
+				},
+				_viewportIsMinHeight: Boolean
 			},
 
 			_container: null,
@@ -146,7 +151,7 @@
 
 				var innerContainer = this._container.querySelector('div');
 
-				if (this._heightAtMost500px || ((containerTop + containerRect.height) <= viewBottom)) {
+				if (this._viewportIsMinHeight || ((containerTop + containerRect.height) <= viewBottom)) {
 
 					if (!isFloating) {
 						return;

--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -68,7 +68,7 @@
 			}
 		</style>
 
-		<iron-media-query query="(max-height: [[minHeight]])" query-matches="{{_viewportIsAtleastMinHeight}}"></iron-media-query>
+		<iron-media-query query="(max-height: [[minHeight]])" query-matches="{{_viewportIsAtLeastMinHeight}}"></iron-media-query>
 
 		<div class="d2l-floating-buttons-container">
 			<div><content></content></div>
@@ -87,7 +87,7 @@
 					type: String,
 					value: '500px'
 				},
-				_viewportIsAtleastMinHeight: Boolean
+				_viewportIsAtLeastMinHeight: Boolean
 			},
 
 			_container: null,
@@ -151,7 +151,7 @@
 
 				var innerContainer = this._container.querySelector('div');
 
-				if (this._viewportIsAtleastMinHeight || ((containerTop + containerRect.height) <= viewBottom)) {
+				if (this._viewportIsAtLeastMinHeight || ((containerTop + containerRect.height) <= viewBottom)) {
 
 					if (!isFloating) {
 						return;

--- a/d2l-floating-buttons.html
+++ b/d2l-floating-buttons.html
@@ -68,7 +68,7 @@
 			}
 		</style>
 
-		<iron-media-query query="(max-height: {{minHeight}})" query-matches="{{_viewportIsMinHeight}}"></iron-media-query>
+		<iron-media-query query="(max-height: [[minHeight]])" query-matches="{{_viewportIsAtleastMinHeight}}"></iron-media-query>
 
 		<div class="d2l-floating-buttons-container">
 			<div><content></content></div>
@@ -87,7 +87,7 @@
 					type: String,
 					value: '500px'
 				},
-				_viewportIsMinHeight: Boolean
+				_viewportIsAtleastMinHeight: Boolean
 			},
 
 			_container: null,
@@ -151,7 +151,7 @@
 
 				var innerContainer = this._container.querySelector('div');
 
-				if (this._viewportIsMinHeight || ((containerTop + containerRect.height) <= viewBottom)) {
+				if (this._viewportIsAtleastMinHeight || ((containerTop + containerRect.height) <= viewBottom)) {
 
 					if (!isFloating) {
 						return;

--- a/test/floating-buttons.html
+++ b/test/floating-buttons.html
@@ -90,6 +90,17 @@
 				expect(buttons[0]).to.equal(floatingButtons.querySelector('button'));
 			});
 
+			it('does not float when min height is smaller than viewport', function() {
+
+				var content = document.createElement('div');
+				floatingButtons.setAttribute('min-height', '10px');
+				floatingButtons.parentNode.insertBefore(content, floatingButtons);
+
+				expect(floatingButtons.isFloating()).to.be.false;
+				floatingButtons.setAttribute('min-height', '500px');
+
+			});
+
 		});
 
 		</script>


### PR DESCRIPTION
…oating), previously always 500px

- Need this for email previews - we want floating buttons but we want the floating behavior to be more aggressive (probably about 200px, to be defined in LMS)
- I didn't document this in the readme because I don't know if we want this to be used heavily, for now it seems exceptional
- I found the test code a little finicky... had to reset the attribute back to 500px.  I didn't expect to have to do that (I thought the test fixture was recreated for each test) - but it seemed to effect other tests...  Related, I remember there were some limitations with setting the viewport height so I didn't try to make the new test anymore complicated than it is.