### PR TITLE
extract button styles into mixins and create .d2l-button style that c…

### DIFF
--- a/d2l-button-shared-styles.html
+++ b/d2l-button-shared-styles.html
@@ -79,7 +79,7 @@
 	.d2l-button, .d2l-button[disabled]:hover, .d2l-button[disabled]:focus {
 		@apply --d2l-button-disabled-hover-focus;
 	}
-	.d2l-button:hover, d2l-button.d2l-button-hover {
+	.d2l-button:hover, .d2l-button.d2l-button-hover {
 		@apply --d2l-button-hover-color;
 		@apply(--d2l-button-hover);
 	}

--- a/d2l-button-shared-styles.html
+++ b/d2l-button-shared-styles.html
@@ -1,6 +1,34 @@
 <link rel="import" href="../polymer/polymer.html">
 <style is="custom-style">
 	html {
+		--d2l-button-default: {
+			border-width: 1px;
+			border-style: solid;
+			border-radius: 0.3rem;
+			box-sizing: border-box;
+			cursor: pointer;
+			display: inline-block;
+			font-family: inherit;
+			font-size: 0.7rem;
+			font-weight: 700;
+			letter-spacing: 0.02rem;
+			line-height: 1rem;
+			margin: 0;
+			min-height: -webkit-calc(2rem + 2px);
+			min-height: calc(2rem + 2px);
+			outline: none;
+			padding: 0.5rem 1.5rem;
+			text-align: center;
+			transition: box-shadow 0.2s;
+			-webkit-user-select: none;
+			-moz-user-select: none;
+			-ms-user-select: none;
+			user-select: none;
+			vertical-align: middle;
+			white-space: nowrap;
+			width: auto;
+			text-decoration: none;
+		};
 		--d2l-button-clear-focus: {
 			box-shadow: 0 0 0 4px rgba(0, 0, 0, 0);
 		};
@@ -12,6 +40,26 @@
 			box-shadow: 0 0 0 4px rgba(0, 111, 191, 0.3);
 		};
 		--d2l-button-spacing: 0.75rem;
+		--d2l-button-disabled-hover-focus: {
+			background-color: var(--d2l-color-woolonardo);
+			border-color: var(--d2l-color-titanius);
+			color: var(--d2l-color-ferrite);
+		};
+		--d2l-button-hover-color: {
+			background-color: var(--d2l-color-gypsum);
+		};
+		--d2l-button-disabled: {
+			opacity: 0.5;
+			cursor: default;
+		};
+		--d2l-button-primary-disabled-hover-focus: {
+			background-color: var(--d2l-color-celestine);
+			border-color: var(--d2l-color-celestuba);
+			color: var(--d2l-color-white);
+		};
+		--d2l-button-primary-hover-color: {
+			background-color: var(--d2l-color-celestuba);
+		}
 	}
 	.d2l-button-spacing {
 		margin-right: var(--d2l-button-spacing);
@@ -20,4 +68,37 @@
 		margin-left: var(--d2l-button-spacing);
 		margin-right: 0;
 	}
+	.d2l-button {
+		@apply --d2l-button-default;
+		@apply --d2l-button;
+		@apply --d2l-button-clear-focus;
+	}
+	.d2l-button::-moz-focus-inner {
+		border: 0;
+	}
+	.d2l-button, .d2l-button[disabled]:hover, .d2l-button[disabled]:focus {
+		@apply --d2l-button-disabled-hover-focus;
+	}
+	.d2l-button:hover, d2l-button.d2l-button-hover {
+		@apply --d2l-button-hover-color;
+		@apply(--d2l-button-hover);
+	}
+	.d2l-button:focus, .d2l-button.d2l-button-focus {
+		@apply(--d2l-secondary-button-focus);
+	}
+	.d2l-button[disabled] {
+		@apply --d2l-button-disabled;
+	}
+	.d2l-button[primary], .d2l-button[primary][disabled]:hover, .d2l-button[primary][disabled]:focus {
+		@apply --d2l-button-primary-disabled-hover-focus;
+		@apply(--d2l-button-primary);
+	}
+	.d2l-button[primary]:hover, .d2l-button[primary].d2l-button-hover {
+		@apply --d2l-button-primary-hover-color;
+		@apply(--d2l-button-primary-hover);
+	}
+	.d2l-button[primary]:focus, .d2l-button[primary].d2l-button-focus {
+		@apply(--d2l-primary-button-focus);
+	}
+
 </style>

--- a/d2l-button.html
+++ b/d2l-button.html
@@ -6,31 +6,7 @@
 	<template>
 		<style>
 			:host {
-				border-width: 1px;
-				border-style: solid;
-				border-radius: 0.3rem;
-				box-sizing: border-box;
-				cursor: pointer;
-				display: inline-block;
-				font-family: inherit;
-				font-size: 0.7rem;
-				font-weight: 700;
-				letter-spacing: 0.02rem;
-				line-height: 1rem;
-				margin: 0;
-				min-height: -webkit-calc(2rem + 2px);
-				min-height: calc(2rem + 2px);
-				outline: none;
-				padding: 0.5rem 1.5rem;
-				text-align: center;
-				transition: box-shadow 0.2s;
-				-webkit-user-select: none;
-				-moz-user-select: none;
-				-ms-user-select: none;
-				user-select: none;
-				vertical-align: middle;
-				white-space: nowrap;
-				width: auto;
+				@apply(--d2l-button-default);
 				@apply(--d2l-button);
 				@apply(--d2l-button-clear-focus);
 			}
@@ -39,32 +15,24 @@
 				border: 0;
 			}
 			:host, :host([disabled]:hover), :host([disabled]:focus) {
-				background-color: var(--d2l-color-woolonardo);
-				border-color: var(--d2l-color-titanius);
-				color: var(--d2l-color-ferrite);
+				@apply --d2l-button-disabled-hover-focus;
 			}
-
 			:host(:hover), :host(.d2l-button-hover) {
-				background-color: var(--d2l-color-gypsum);
+				@apply --d2l-button-hover-color;
 				@apply(--d2l-button-hover);
 			}
 			:host(:focus), :host(.d2l-button-focus) {
 				@apply(--d2l-secondary-button-focus);
 			}
-
 			:host([disabled]) {
-				opacity: 0.5;
-				cursor: default;
+				@apply --d2l-button-disabled;
 			}
 			:host([primary]), :host([primary][disabled]:hover), :host([primary][disabled]:focus) {
-				background-color: var(--d2l-color-celestine);
-				border-color: var(--d2l-color-celestuba);
-				color: var(--d2l-color-white);
+				@apply --d2l-button-primary-disabled-hover-focus;
 				@apply(--d2l-button-primary);
 			}
-
 			:host([primary]:hover), :host([primary].d2l-button-hover) {
-				background-color: var(--d2l-color-celestuba);
+				@apply --d2l-button-primary-hover-color;
 				@apply(--d2l-button-primary-hover);
 			}
 			:host([primary]:focus), :host([primary].d2l-button-focus) {

--- a/demo/button-tag.html
+++ b/demo/button-tag.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+	<title></title>
+	<script src="https://s.brightspace.com/lib/webcomponentsjs/0.7.21/webcomponents.min.js"></script>
+	<link rel="import" href="../../d2l-demo-template/d2l-demo-template.html">
+	<link rel="import" href="../d2l-button-shared-styles.html">
+</head>
+<body unresolved>
+
+	<d2l-demo-template title="Button tags">
+		<div class="d2l-demo-fixture">
+			<a href="http://d2l.com" class="d2l-button">Normal Button</a>
+			<a href="http://d2l.com" primary class="d2l-button">Primary Button</a>
+			<a href="http://d2l.com" disabled class="d2l-button">Disabled Button</a>
+			<a href="http://d2l.com" primary disabled class="d2l-button">Disabled Primary Button</a>
+		</div>
+	</d2l-demo-template>
+
+</body>
+</html>

--- a/demo/button.html
+++ b/demo/button.html
@@ -15,6 +15,10 @@
 
 			<button is="d2l-button" primary>Primary Button</button>
 
+			<button is="d2l-button" disabled>Disabled Button</button>
+
+			<button is="d2l-button" primary disabled>Disabled Primary Button</button>
+
 		</div>
 	</d2l-demo-template>
 


### PR DESCRIPTION
…an be used to style other tags to look like buttons.

Initial attempt at extracting shared button styles to be used by both d2l-button and other tags e.g. <a> styled as d2l-buttons.

e.g.
`<a href="http://d2l.com" class="d2l-button">D2L</a`

Disabled states only apply to styling. The disabled attribute is ignored on <a> elements.
I've punted on how to actually disable the anchor if it is desired.  There are numerous approaches that a client might like to use, so leaving it to the client.

I've left updating docs/tests (e.g. galen) until we agree whether this is an approach we'd like to take.