### PR TITLE
Delegate the focus to the underlying button element for focus method.

### DIFF
--- a/d2l-button.html
+++ b/d2l-button.html
@@ -91,7 +91,10 @@
 	<script>
 		Polymer({
 			is: 'd2l-button',
-			behaviors: [window.D2L.PolymerBehaviors.Button.Behavior]
+			behaviors: [window.D2L.PolymerBehaviors.Button.Behavior],
+			focus: function() {
+				Polymer.dom(this.root).querySelector('button').focus();
+			}
 		});
 	</script>
 </dom-module>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -28,7 +28,7 @@
 				{
 					"browserName": "safari",
 					"platform": "OS X 10.12",
-					"version": "10.0"
+					"version": ""
 				},
 				{
 					"browserName": "microsoftedge",


### PR DESCRIPTION
With the change to wrap `button`, we need to apply focus to the underlying `button` element when consumers call `focus` method.  All components get a native focus method - this just overrides it to correctly apply focus.  I noticed that dropdown focus was not being applied correctly to button opener when closing the dropdown.  @dlockhart : look ok?
