### PR TITLE
fix rtl behaviour

### DIFF
--- a/d2l-button-icon.html
+++ b/d2l-button-icon.html
@@ -37,11 +37,11 @@ Polymer-based web component for icon buttons
 			:host([h-align="text"]) button {
 				left: calc(((var(--d2l-button-icon-min-width) - 0.9rem) / 2) * -1);
 			}
-			:host-context([dir="rtl"])[h-align="text"] button {
+			:host(:dir(rtl))[h-align="text"] button {
 				left: 0;
 				right: calc(((var(--d2l-button-icon-min-width) - 0.9rem) / 2) * -1);
 			}
-			:host(:dir(rtl)[h-align="text"]) button {
+			:host(:host-context([dir="rtl"])[h-align="text"]) button {
 				left: 0;
 				right: calc(((var(--d2l-button-icon-min-width) - 0.9rem) / 2) * -1);
 			}

--- a/d2l-button-subtle.html
+++ b/d2l-button-subtle.html
@@ -33,11 +33,11 @@ Polymer-based web component for subtle buttons
 			:host([h-align="text"]) button {
 				left: -0.6rem;
 			}
-			:host-context([dir="rtl"])[h-align="text"] button {
+			:host(:dir(rtl))[h-align="text"] button {
 				left: 0;
 				right: -0.6rem;
 			}
-			:host(:dir(rtl)[h-align="text"]) button {
+			:host(:host-context([dir="rtl"])[h-align="text"]) button {
 				left: 0;
 				right: -0.6rem;
 			}
@@ -70,19 +70,19 @@ Polymer-based web component for subtle buttons
 				padding-left: 0;
 				padding-right: 1.2rem;
 			}
-			:host-context([dir="rtl"])[icon] .d2l-button-subtle-content {
+			:host(:dir(rtl))[icon] .d2l-button-subtle-content {
 				padding-left: 0;
 				padding-right: 1.2rem;
 			}
-			:host(:dir(rtl)[icon]) .d2l-button-subtle-content {
+			:host(:host-context([dir="rtl"])[icon]) .d2l-button-subtle-content {
 				padding-left: 0;
 				padding-right: 1.2rem;
 			}
-			:host-context([dir="rtl"])[icon][icon-right] .d2l-button-subtle-content {
+			:host(:dir(rtl))[icon][icon-right] .d2l-button-subtle-content {
 				padding-left: 1.2rem;
 				padding-right: 0;
 			}
-			:host(:dir(rtl)[icon][icon-right]) .d2l-button-subtle-content {
+			:host(:host-context([dir="rtl"])[icon][icon-right]) .d2l-button-subtle-content {
 				padding-left: 1.2rem;
 				padding-right: 0;
 			}
@@ -102,18 +102,11 @@ Polymer-based web component for subtle buttons
 			:host([icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
 				right: 0.6rem;
 			}
-
-			:host-context([dir="rtl"])[icon] d2l-icon.d2l-button-subtle-icon {
-				right: 0.6rem;
-			}
-			:host(:dir(rtl)[icon]) d2l-icon.d2l-button-subtle-icon {
-				right: 0.6rem;
-			}
-			:host-context([dir="rtl"])[icon][icon-right] d2l-icon.d2l-button-subtle-icon {
+			:host(:dir(rtl))[icon][icon-right] d2l-icon.d2l-button-subtle-icon {
 				left: 0.6rem;
 				right: initial;
 			}
-			:host(:dir(rtl)[icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
+			:host(:host-context([dir="rtl"])[icon][icon-right]) d2l-icon.d2l-button-subtle-icon {
 				left: 0.6rem;
 				right: initial;
 			}


### PR DESCRIPTION
Subtle and icon buttons should now work with all combos of polymer 1 or 2 with shady or shadow

fixes https://github.com/BrightspaceUI/button/issues/117