### PR TITLE
Fix alignment for narrow buttons

### DIFF
--- a/d2l-button-shared-styles.html
+++ b/d2l-button-shared-styles.html
@@ -10,6 +10,7 @@
 				cursor: pointer;
 				display: inline-block;
 				margin: 0;
+				padding: 0;
 				min-height: calc(2rem + 2px);
 				outline: none;
 				text-align: center;


### PR DESCRIPTION
The default padding applied by browsers can misalign the icon of an icon button if the icon is wider than the button minus the width of the padding. (This caught our eye on Safari on iPad, as it adds a whole `em` padding to the button.)
Overriding that padding to be 0 allows for correctly centered icons, even if the overall button is narrower than the sum of default-padding-left + icon-width + default-padding-right.

Button icon pushed off-center by padding on iPad:
![ipad-icon-off-center](https://user-images.githubusercontent.com/32819802/46693290-377d8d80-cbbe-11e8-83f7-af5e5edfea81.png)
<img width="675" alt="screen shot 2018-10-09 at 11 39 59 am" src="https://user-images.githubusercontent.com/32819802/46693364-727fc100-cbbe-11e8-95cf-f90260deb2e9.png">

