### PR TITLE
prevent user tapping and triggering action when a button is disabled

### DIFF
--- a/d2l-button-behavior.html
+++ b/d2l-button-behavior.html
@@ -101,8 +101,15 @@ D2L.PolymerBehaviors.Button.Behavior = {
 			reflectToAttribute: true
 		}
 
+	},
+	ready: function() {
+		this.addEventListener('tap', function(e) {
+			var button = e.currentTarget;
+			if (button && button.disabled) {
+				e.stopPropagation();
+			}
+		}, true);
 	}
-
 };
 
 </script>

--- a/d2l-button-icon.html
+++ b/d2l-button-icon.html
@@ -30,7 +30,6 @@ Polymer-based web component for icon buttons
 			:host([hidden]) {
 				display: none;
 			}
-
 			button {
 				background-color: transparent;
 				border-color: transparent;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -25,7 +25,7 @@
         {
           "browserName": "safari",
           "platform": "OS X 10.13",
-          "version": ""
+          "version": "11.1"
         },
         {
           "browserName": "microsoftedge",


### PR DESCRIPTION
Background: Native html button prevents user from clicking when it is disabled. However, our custom buttons doesn't prevent user from clicking and actions associated with it still get triggered.

This pull request is to prevent user from clicking our custom buttons when they are disabled. 

