### PR TITLE
Move span outside of slot to fix Galen tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ The `primary` and `disabled` attributes work the same way as they do with the we
 
 The subtle button shows text with an optional icon, and can be added by using the `<d2l-button-subtle>` custom element. It should be used for advanced or de-emphasized actions.
 
+- It is strongly recommended to use `text` and `icon` as opposed to putting content in the `slot` to ensure that the recommended subtle button style is maintained.
+
+
 Without icon:
 
 ![screenshot of subtle buttons without icons](/screenshots/button-subtle.png?raw=true)

--- a/d2l-button-subtle.html
+++ b/d2l-button-subtle.html
@@ -160,7 +160,8 @@ Polymer-based web component for subtle buttons
 			name$=[[name]]
 			type$=[[type]]>
 			<d2l-icon icon=[[icon]] class="d2l-button-subtle-icon"></d2l-icon>
-			<slot><span class="d2l-button-subtle-content">[[text]]</span></slot>
+			<span class="d2l-button-subtle-content">[[text]]</span>
+			<slot></slot>
 		</button>
 	</template>
 	<script>


### PR DESCRIPTION
Some context:
> Continuing the conversation from #141 (comment):
@AdmiralCoco After some more digging, it looks like shady dom is patching the parentNode accessor, so the span element's parent is <slot>. Selenium checks element visibility by going through all the parent nodes and if one if them is not visible (like <slot>), the element is not considered visible.
I'm not sure how to fix this, but it is unrelated to Polymer 3 conversion. I think it's coming up now because shadydom might've been updated with the new webcomponents

