### PR TITLE
Add width:100% to the actual button

### DIFF
--- a/d2l-button.js
+++ b/d2l-button.js
@@ -35,6 +35,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button">
 				@apply --d2l-label-text;
 				@apply --d2l-button;
 				@apply --d2l-button-clear-focus;
+				width: 100%;
 			}
 			/* Firefox includes a hidden border which messes up button dimensions */
 			button::-moz-focus-inner {


### PR DESCRIPTION
The intent with this change was so that I could make a "wide" button, e.g.,:
![image](https://user-images.githubusercontent.com/6110668/51213856-1d082e00-18ea-11e9-8da8-6cf996305b8b.png)
without having to use the `--d2l-button` mixin.

Dave and I chatted offline and decided to apply this just to `d2l-button` for now

(context for not wanting to use the mixin [here](https://d2l.slack.com/archives/C0PHG3QB0/p1547589229027900))