### PR TITLE
Update translucent button-icon focus style for wcag 2.1.

### DIFF
--- a/d2l-button-icon.js
+++ b/d2l-button-icon.js
@@ -93,8 +93,15 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 
 			:host([translucent]) button {
 				background-color: rgba(0,0,0,0.5);
-				transition: background-color 0.5s;
+				transition-property: background-color, box-shadow;
+				transition-duration: 0.2s, 0.2s;
+				box-shadow: inset 0px 0px 0px 2px transparent, inset 0px 0px 0px 3px transparent;
 			}
+
+			:host([translucent][visible-on-ancestor]) button {
+				transition-duration: 0.4s, 0.4s;
+			}
+
 			:host([translucent]) .d2l-button-icon {
 				color: white;
 			}
@@ -105,7 +112,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 			:host([translucent]) button:focus {
 				border: none;
 				background-color: var(--d2l-color-celestine);
-				box-shadow: none;
+			}
+
+			:host([translucent]) button:focus {
+				box-shadow: inset 0px 0px 0px 2px var(--d2l-color-celestine), inset 0px 0px 0px 3px white;
 			}
 
 			button[disabled] {


### PR DESCRIPTION
This adds the inset focus effect for `d2l-button-icon`'s `translucent` mode.

![button-icon-translucent](https://user-images.githubusercontent.com/9042472/58438065-ee217600-809a-11e9-85b8-01cd8dd54c5a.png)

This uses the `box-shadow` similar to how we'd done previously, which causes layout.  We could also accomplish this with an extra internal `div` and just change the border color, which would avoid layout but still requires paint. I profiled with the `box-shadow` solution and was hitting 55-61fps.  Adding an extra `div` just for this seems a bit extraneous.  Let me know if you think we should go that route instead. Aside from that, confirming animating timing with Sarah.