### PR TITLE
use the text as the aria-label if aria-label is unset

### DIFF
--- a/d2l-button-icon.js
+++ b/d2l-button-icon.js
@@ -126,7 +126,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 		<button
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
-			aria-label$="[[ariaLabel]]"
+			aria-label$="[[_ariaLabel]]"
 			class="d2l-focusable"
 			disabled$="[[disabled]]"
 			autofocus$="[[autofocus]]"
@@ -183,6 +183,11 @@ Polymer({
 		translucent: {
 			type: Boolean,
 			reflectToAttribute: true
+		},
+
+		_ariaLabel: {
+			type: String,
+			computed: 'computeAriaLabel(ariaLabel, text)'
 		}
 
 	},
@@ -191,6 +196,13 @@ Polymer({
 		D2L.PolymerBehaviors.Button.Behavior,
 		D2L.PolymerBehaviors.FocusableBehavior,
 		D2L.PolymerBehaviors.VisibleOnAncestorBehavior
-	]
+	],
+
+	computeAriaLabel: function(ariaLabel, text) {
+		if (ariaLabel !== undefined && ariaLabel !== null && ariaLabel.length > 0) {
+			return ariaLabel;
+		}
+		return text;
+	}
 
 });

--- a/test/button-icon.html
+++ b/test/button-icon.html
@@ -79,6 +79,18 @@ describe('<d2l-button-icon>', function() {
 			var title = button.$$('button').getAttribute('title');
 			expect(title).to.equal('Icon Button');
 		});
+
+		it('should reflect the text attribute to aria-label if aria-label not set', function() {
+			var ariaLabel = button.$$('button').getAttribute('aria-label');
+			expect(ariaLabel).to.equal('Icon Button');
+		});
+
+		it('should reflect the aria-label attribute to aria-label if set', function() {
+			button.setAttribute('aria-label', 'aria label');
+			var ariaLabel = button.$$('button').getAttribute('aria-label');
+			expect(ariaLabel).to.equal('aria label');
+		});
+
 	});
 });
 </script>


### PR DESCRIPTION
Not needed in core as [we already do this](https://github.com/BrightspaceUI/core/blob/master/components/button/button-icon.js#L107).

Subtle buttons are OK as they require `text` and the text is rendered visibly.