### PR TITLE
Custom box shadow

### DIFF
--- a/d2l-button-icon.js
+++ b/d2l-button-icon.js
@@ -47,6 +47,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 				border-radius: var(--d2l-button-icon-border-radius);
 				min-height: var(--d2l-button-icon-min-height);
 				min-width: var(--d2l-button-icon-min-width);
+				padding: 0;
 				position: relative;
 			}
 

--- a/d2l-button-icon.js
+++ b/d2l-button-icon.js
@@ -26,6 +26,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 			:host {
 				display: inline-block;
 				--d2l-button-icon-border-radius: 0.3rem;
+				--d2l-button-icon-focus-box-shadow: 0 0 0 2px #ffffff, 0 0 0 4px #006fbf;
 				--d2l-button-icon-min-height: calc(2rem + 2px);
 				--d2l-button-icon-min-width: calc(2rem + 2px);
 				--d2l-button-icon-h-align: calc(((2rem + 2px - 0.9rem) / 2) * -1);
@@ -85,6 +86,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 			}
 			button:focus, :host(.d2l-button-icon-focus) button {
 				@apply --d2l-button-focus;
+				box-shadow: var(--d2l-button-icon-focus-box-shadow);
 			}
 
 			.d2l-button-icon {


### PR DESCRIPTION
These changes are needed by the search input, which needs to further shrink the button from `34px` down to `30px` in width & height and reduce the focus box shadow so that there's only `1px` of space between the button and the border:

<img width="579" alt="Screen Shot 2019-05-29 at 5 13 07 PM" src="https://user-images.githubusercontent.com/5491151/58591792-12b15580-8235-11e9-9e69-212cca886361.png">

I had to kill the padding because by default, the user agent puts `7px` of padding on buttons. We hadn't noticed this before because our `min-width` and `min-height` were making the buttons large enough such that the padding had no impact. But with the smaller `30px` button we need for search, `7px` top padding + `0.9rem` (`18px`) icon size + `7px` bottom padding is `32px`.

If this looks OK I'll make the same changes to core.