### PR TITLE
Fix edge outline

### DIFF
--- a/d2l-button-icon.js
+++ b/d2l-button-icon.js
@@ -87,6 +87,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 			button:focus, :host(.d2l-button-icon-focus) button {
 				@apply --d2l-button-focus;
 				box-shadow: var(--d2l-button-icon-focus-box-shadow);
+				outline: none; /* needed for Edge, can't be in the mixin */
 			}
 
 			.d2l-button-icon {

--- a/d2l-button-subtle.js
+++ b/d2l-button-subtle.js
@@ -91,6 +91,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-subtle">
 			}
 			button:focus, :host(.d2l-button-subtle-focus) button {
 				@apply --d2l-button-focus;
+				outline: none; /* needed for Edge, can't be in the mixin */
 			}
 
 			.d2l-button-subtle-content {

--- a/d2l-button.js
+++ b/d2l-button.js
@@ -63,6 +63,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button">
 			}
 			button:focus, :host(.d2l-button-focus) button {
 				@apply --d2l-button-focus;
+				outline: none; /* needed for Edge, can't be in the mixin */
 			}
 
 			button[disabled] {

--- a/d2l-button.scss
+++ b/d2l-button.scss
@@ -38,6 +38,7 @@
 	@include _d2l-button-clear-focus();
 	font-family: inherit;
 	min-width: calc(2rem + 2px);
+	padding: 0;
 	position: relative;
 	&::-moz-focus-inner {
 		border: 0;


### PR DESCRIPTION
I think this has been a problem for a while, and seems to be a Polymer mixin issue, as the Sass-based buttons have no issues.

Basically in Edge when you focus on any of our buttons, you get an ugly outline:
<img width="74" alt="Screen Shot 2019-05-30 at 1 30 08 PM" src="https://user-images.githubusercontent.com/5491151/58651424-4a74d780-82df-11e9-9f3f-bef387808537.png">

Fixing this in the focus mixin doesn't work, it has to explicitly live with each button type.
