### PR TITLE
no line-height on buttons so the smaller buttons work

### DIFF
--- a/d2l-button-icon.js
+++ b/d2l-button-icon.js
@@ -46,6 +46,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-button-icon">
 				@apply --d2l-button-clear-focus;
 				@apply --d2l-button-shared;
 				border-radius: var(--d2l-button-icon-border-radius);
+				line-height: 1px;
 				min-height: var(--d2l-button-icon-min-height);
 				min-width: var(--d2l-button-icon-min-width);
 				padding: 0;


### PR DESCRIPTION
The issue here is that when you override the height of the button (like for search), the whitespace (even with `strip-whitespace`) causes it to have a minimum height of `31px` in Chrome. We need `30px`. That's coming from typography, which is giving it a line-height of `1.4rem` (`28px`).