### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "d2l-floating-buttons.js"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@brightspace-ui/core": "^2",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564